### PR TITLE
Fixed race conditions in PSWebSocket(Buffer)

### DIFF
--- a/PocketSocket/PSWebSocketBuffer.h
+++ b/PocketSocket/PSWebSocketBuffer.h
@@ -19,8 +19,8 @@
 
 #pragma mark - Properties
 
-@property (nonatomic, assign) NSInteger offset;
-@property (nonatomic, assign) NSUInteger compactionLength;
+@property (atomic, assign) NSInteger offset;
+@property (atomic, assign) NSUInteger compactionLength;
 
 #pragma mark - Actions
 

--- a/PocketSocket/PSWebSocketBuffer.m
+++ b/PocketSocket/PSWebSocketBuffer.m
@@ -26,7 +26,7 @@
 - (instancetype)init {
     if((self = [super init])) {
         _data = [NSMutableData data];
-        _offset = 0;
+        self.offset = 0;
         _compactionLength = 4096;
     }
     return self;
@@ -35,11 +35,11 @@
 #pragma mark - Actions
 
 - (BOOL)hasBytesAvailable {
-    return _data.length > _offset;
+    return _data.length > self.offset;
 }
 - (NSUInteger)bytesAvailable {
-    if(_data.length > _offset) {
-        return _data.length - _offset;
+    if(_data.length > self.offset) {
+        return _data.length - self.offset;
     }
     return 0;
 }
@@ -50,21 +50,21 @@
     [_data appendBytes:bytes length:length];
 }
 - (void)compact {
-    if(_offset > _compactionLength && _offset > (_data.length >> 1)) {
-        _data = [NSMutableData dataWithBytes:(char *)_data.bytes + _offset
-                                      length:_data.length - _offset];
-        _offset = 0;
+    if(self.offset > _compactionLength && self.offset > (_data.length >> 1)) {
+        _data = [NSMutableData dataWithBytes:(char *)_data.bytes + self.offset
+                                      length:_data.length - self.offset];
+        self.offset = 0;
     }
 }
 - (void)reset {
-    _offset = 0;
+    self.offset = 0;
     _data.length = 0;
 }
 - (const void *)bytes {
-    return _data.bytes + _offset;
+    return _data.bytes + self.offset;
 }
 - (void *)mutableBytes {
-    return _data.mutableBytes + _offset;
+    return _data.mutableBytes + self.offset;
 }
 - (NSData *)data {
     return [_data copy];


### PR DESCRIPTION
Many properties in PSWebSocket are not thread safe, while they were used from different threads. To offer a solution for now without digging too deep in the PocketSocket codebase, I've changed the problematic properties to atomic. This fixed the race condition according to Xcode's thread sanitizer.