### PR TITLE
Fixed header import case

### DIFF
--- a/PocketSocket/PSWebSocketServer.m
+++ b/PocketSocket/PSWebSocketServer.m
@@ -13,7 +13,7 @@
 //  limitations under the License.
 
 #import "PSWebSocketServer.h"
-#import "PSwebSocket.h"
+#import "PSWebSocket.h"
 #import "PSWebSocketDriver.h"
 #import "PSWebSocketInternal.h"
 #import "PSWebSocketBuffer.h"


### PR DESCRIPTION
This resolves a warning when compiling with Xcode 8.3.